### PR TITLE
프론트엔드 내역 페이지 내역 추가 구현

### DIFF
--- a/client/src/App/apis/endpoints.js
+++ b/client/src/App/apis/endpoints.js
@@ -1,13 +1,15 @@
+const URL = 'http://localhost:3000/'
+
 export const EndPoints = {
   // 모든 거래 내역을 가져옵니다.
   GET_HKBHIST :{
     method : 'GET',
-    url: 'api/hkbhist',
+    url: URL + 'api/hkbhist',
   },
   // 새로운 거래 내역을 만듭니다.
   POST_HKBHIST :{
     method : 'POST',
-    url: 'api/hkbhist',
+    url: URL + 'api/hkbhist',
   },
   // {id} 거래 내역을 업데이트 합니다.
   PUT_HKBHIST :{
@@ -22,7 +24,7 @@ export const EndPoints = {
   // 모든 결제수단을 가져옵니다.
   GET_PAYMENT :{
     method : 'GET',
-    url: 'api/payment',
+    url: URL + 'api/payment',
   },
   // 새로운 결제수단을 만듭니다
   POST_PAYMENT :{
@@ -37,7 +39,7 @@ export const EndPoints = {
   // {type} 타입별 결제수단을 가져옵니다.
   GET_CATEGORY :{
     method : 'GET',
-    url: 'api/category?type=',
+    url: URL + 'api/category',
   },
   // 새로운 사용자를 등록합니다.
   POST_USER :{

--- a/client/src/App/apis/index.js
+++ b/client/src/App/apis/index.js
@@ -1,27 +1,62 @@
 import { EndPoints } from './endpoints';
 
-export const getAllHkbHist = async () => {
-  const res = await fetch(EndPoints.GET_HKBHIST.url, {
-    method: EndPoints.GET_HKBHIST.method,
-    headers: {
-      "Content-Type": "application/json",
-    },
+export async function getAllHkbHist() {
+  return new Promise((resolve, reject) => {
+    fetch(EndPoints.GET_HKBHIST.url, {
+      method: EndPoints.GET_HKBHIST.method,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch((error) => reject(error));
   });
-
-  console.log(res);
-  return res;
 };
 
 export const createHkbHist = async (data) => {
-  const res = await fetch(EndPoints.POST_HKBHIST.url, {
-    method : EndPoints.POST_HKBHIST.method,
-    body: JSON.stringify(data),
+  return new Promise((resolve, reject) => {
+    fetch(EndPoints.POST_HKBHIST.url, {
+      method : EndPoints.POST_HKBHIST.method,
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch((error) => reject(error));
   });
-
-  console.log(res);
-  return res;
 };
 
+
+export async function getCategory() {
+  return new Promise((resolve, reject) => {
+    fetch(EndPoints.GET_CATEGORY.url, {
+      method: EndPoints.GET_CATEGORY.method,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch((error) => reject(error));
+  });
+};
+
+export async function getPayment() {
+  return new Promise((resolve, reject) => {
+    fetch(EndPoints.GET_PAYMENT.url, {
+      method: EndPoints.GET_PAYMENT.method,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch((error) => reject(error));
+  });
+};
 export const getLogin = async () => {
   const res = await fetch(EndPoints.GET_LOGIN.url, {
     method: EndPoints.GET_LOGIN.method,

--- a/client/src/App/components/dailyHistory/index.js
+++ b/client/src/App/components/dailyHistory/index.js
@@ -22,7 +22,7 @@ const DailyHistory = (date, data) => {
         <span class='income_amount'>+${numberWithCommas(dayAllIncome)}원</span>
         <span class='expense_amount'>-${numberWithCommas(dayAllExpense)}원</span>
       </th>
-      ${data.map((item) => CaseHistory(item)).join('')}
+      ${data.reverse().map((item) => CaseHistory(item)).join('')}
     </table>
   `;
 };

--- a/client/src/App/components/hkbForm/index.js
+++ b/client/src/App/components/hkbForm/index.js
@@ -1,52 +1,63 @@
 import './hkbForm.scss';
-import { getState, setState } from '../../store';
-import { numberWithCommas, getMonth, getDate } from '../../utils';
+import { getState, registerEvent } from '../../store';
+import { numberWithCommas, getFullDate } from '../../utils';
 
 const HkbForm = () => {
-  const categoryList = ['식비', '생활', '교통'];
-  const paymentList = ['국민은행', '현대카드'];
+  const currentType = getState('currentType');
+  const category = getState('category').filter((item) => item.type === currentType); //['식비', '생활', '교통'];
+  const payment = getState('payment'); //['국민은행', '현대카드'];
 
   const histDate = new Date();
   const amount = 0;
 
-  const dateFormat = (date) => {
-    const year = date.getFullYear();
-    const month = getMonth(date);
-    const day = getDate(date);
-    const dateForm = `${year}-${month}-${day}`;
-    return dateForm;
+  const getNameList = (data) => {
+    const list = data.map((item) => item.name);
+    return list;
   };
+
+  function onChange() {
+    // 거래 내역에서 분류가 바뀔 때 update 해주어야 할 것 - 분류, 카테고리
+    const currentType = getState('currentType');
+    const category = getState('category').filter((item) => item.type === currentType);
+    const hkbForm = document.querySelector('.hkb_form');
+    const categorySelect = hkbForm.querySelector('.category');
+    categorySelect.innerHTML = '<option value="">선택하세요.</option>' + getNameList(category)
+      .map((item) => `<option value="${item}">${item}</option>`)
+      .join('');
+  }
+
+  registerEvent('currentType',onChange);
 
   return `
   <div class='hkb_form'>
     <div class='row'>
       <div class='col'>
         <label>분류</label>
-        <button class='income active'>수입</button>
+        <button class='income'>수입</button>
         <button class='expense'>지출</button>
       </div>
     </div>
     <div class='row'>
       <div class='col'>
         <label>날짜</label>
-        <input type="date" value="${dateFormat(histDate)}"/>
+        <input type="date" class="createdAt" value="${getFullDate(histDate, '-')}"/>
       </div>
       <div class='col'>
         <label>카테고리</label>
         <select class='category' name="category">
           <option value="">선택하세요.</option>
-          ${categoryList
+          ${getNameList(category)
             .map((item) => `<option value="${item}">${item}</option>`)
-            .join()}
+            .join('')}
         </select>
       </div>
       <div class='col'>
         <label>결제수단</label>
         <select class='payment' name="payment">
         <option value="">선택하세요.</option>
-          ${paymentList
+          ${getNameList(payment)
             .map((item) => `<option value="${item}">${item}</option>`)
-            .join()}}
+            .join('')}
         </select>
       </div>
     </div>
@@ -62,7 +73,7 @@ const HkbForm = () => {
       </div>
       <div class='col'>
         <label>내용</label>
-        <input type='text' value=''/>
+        <input type='text' class="content" value=''/>
       </div>
     </div>
     <div class='row'>

--- a/client/src/App/components/hkbSum/index.js
+++ b/client/src/App/components/hkbSum/index.js
@@ -1,24 +1,41 @@
 import { numberWithCommas } from '../../utils';
+import { registerEvent, getState } from "../../store";
 import './hkbSum.scss';
 
 const HkbSum = (income, expense) => {
   const allIncome = income;
   const allExpense = expense;
   // TODO: checkbox 색상 변경해주기
+
+  function onChangeIncome() {
+    const allIncome = getState('allIncome');
+    const allIncomeDom = document.querySelector('.all_income');
+    allIncomeDom.textContent = `${numberWithCommas(allIncome)} 원`;
+  }
+
+  function onChangeExpense() {
+    const allExpense = getState('allExpense');
+    const allExpenseDom = document.querySelector('.all_expense');
+    allExpenseDom.textContent = `${numberWithCommas(allExpense)} 원`;
+  }
+
+  registerEvent('allIncome',onChangeIncome);
+  registerEvent('allExpense',onChangeExpense);
+
   return `
   <div class='hkb_sum'>
     <div class='row'>
       <input type='checkbox' id='income' checked/>
       <label for="income" class='income'>
         <p class='label'>수입</p>
-        <p>${numberWithCommas(allIncome)} 원</p>
+        <p class="all_income">${numberWithCommas(allIncome)} 원</p>
       </label>
     </div>
     <div class='row'>
       <input type='checkbox' id='expense' checked/>
       <label for="expense" class='expense'>
         <p class='label'>지출</p>
-        <p>${numberWithCommas(allExpense)} 원</p>
+        <p class="all_expense">${numberWithCommas(allExpense)} 원</p>
       </label>
     </div>
   </div>`;

--- a/client/src/App/components/layout/container/container.scss
+++ b/client/src/App/components/layout/container/container.scss
@@ -1,5 +1,4 @@
 .container {
-  height: 100%;
   width: 60%;
-  margin: 0 auto;
+  margin: 0 auto 30px;
 }

--- a/client/src/App/components/layout/layout.scss
+++ b/client/src/App/components/layout/layout.scss
@@ -2,4 +2,5 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }

--- a/client/src/App/event/hkbHist.js
+++ b/client/src/App/event/hkbHist.js
@@ -1,14 +1,55 @@
-import {getState, registerEvent, setState} from "../store";
-import {numberWithCommas} from "../utils";
+import { getState, registerEvent, setState } from "../store";
+import { numberWithCommas, numberWithoutCommas } from "../utils";
+import {createHkbHist, getAllHkbHist} from '../apis';
 
-export function HkbHistClickEvent(e) {
+async function getHkbHistory() {
+  const res = await getAllHkbHist();
+  if(res.success){
+    const data = res.payload.map((item) => ({ ...item, createdAt: new Date(item.createdAt)}));
+    setState('hkbHistory',data);
+  }
+}
+export async function HkbHistClickEvent(e) {
     const confirm = document.querySelector('.hkb_form .confirm');
     if (e.target === confirm) {
+      console.log('내역 추가...');
       // 데이터 추가하기
       // 비었으면 return..
       const form = document.querySelector('.hkb_form');
       const category = form.querySelector('.category');
       const payment = form.querySelector('.payment');
+      const createdAt = form.querySelector('.createdAt');
+      const amount = form.querySelector('.amount');
+      const content = form.querySelector('.content');
+
+      if(!category.value){
+        alert('카테고리를 선택해주세요.');
+        return false;
+      }else if(!payment.value) {
+        alert('결제수단을 선택해주세요.');
+        return false;
+      }else if(parseInt(amount.value) === 0) {
+        alert('금액을 입력해주세요.');
+        return false;
+      }else if(!content.value) {
+        alert('내용을 입력해주세요.');
+        return false;
+      }
+
+      const data = {
+        category: category.value,
+        payment: payment.value,
+        amount: numberWithoutCommas(amount.value),
+        createdAt: new Date(createdAt.value),
+        content: content.value,
+      };
+
+      const res = await createHkbHist(data);
+      console.log(res);
+      if(res.success){
+        getHkbHistory();
+      }
+
     }
 
     const incomeBtn = document.querySelector('.hkb_form .income');

--- a/client/src/App/index.js
+++ b/client/src/App/index.js
@@ -10,10 +10,12 @@ import {
   GraphMouseOut,
   NavigationEvent,
 } from './event';
+import { getAllHkbHist, getCategory, getPayment } from "./apis";
 
 const pageRoute = (path) => {
   const layout = document.querySelector('.contents');
   layout.innerHTML = Route(path);
+  // TODO : 따로 init 함수로 빼기?
   if (path === '/graph') {
     const graphPage = document.querySelector('.graph');
     graphPage.addEventListener('click', GraphEvent);
@@ -25,6 +27,16 @@ const pageRoute = (path) => {
     const hkbPage = document.querySelector('.hkb_page');
     hkbPage.addEventListener('click', HkbHistClickEvent);
     hkbPage.addEventListener('input', HkbHistInputEvent);
+
+    // 분류에 선택 클래스 넣어주기
+    const currentType = getState('currentType');
+    if(currentType === '수입') {
+      const incomeBtn = document.querySelector('.hkb_form .income');
+      incomeBtn.classList.add('active');
+    }else {
+      const expenseBtn = document.querySelector('.hkb_form .expense');
+      expenseBtn.classList.add('active');
+    }
   } else {
 
   }
@@ -38,22 +50,46 @@ const App = () => {
   // 네비게이션 액션 등록
   app.addEventListener('click', NavigationEvent);
 
-  window.addEventListener('DOMContentLoaded', () => {
+  window.addEventListener('DOMContentLoaded',  async () => {
+    if(window.location.pathname !== '/') {
+      const histRes = await getAllHkbHist();
+      if(histRes.success){
+        const data = histRes.payload.map((item) => ({ ...item, createdAt: new Date(item.createdAt)}));
+        setState('hkbHistory',data);
+      }
+      const categoryRes = await getCategory();
+      if(categoryRes.success){
+        setState('category',categoryRes.payload);
+      }
+      const paymentRes = await getPayment();
+      if(paymentRes.success){
+        setState('payment',paymentRes.payload);
+      }
+    }
+
+    let menu;
     if (window.location.pathname === '/hkb') {
       window.history.pushState('/hkb', '', '/hkb');
       setState('path', '/hkb');
       pageRoute('/hkb');
+      menu = document.querySelector('#page_nav_hkb');
+      menu.classList.add('active');
     } else if (window.location.pathname === '/graph') {
       window.history.pushState('/graph', '', '/graph');
       setState('path', '/graph');
       pageRoute('/graph');
+      menu = document.querySelector('#page_nav_graph');
+      menu.classList.add('active');
     } else if (window.location.pathname === '/calendar') {
       window.history.pushState('/calendar', '', '/calendar');
       setState('path', '/calendar');
       pageRoute('/calendar');
+      menu = document.querySelector('#page_nav_calendar');
+      menu.classList.add('active');
     } else {
       window.history.pushState('/', '', '/');
       setState('path', '/');
+
     }
     registerEvent('path', pageRoute);
   });

--- a/client/src/App/pages/hkb/index.js
+++ b/client/src/App/pages/hkb/index.js
@@ -1,31 +1,38 @@
 import {
   HkbForm, HkbSum, DailyHistory,
 } from '../../components';
-import { getState } from '../../store';
+import { getState, setState, registerEvent } from '../../store';
 import {
   getDaysHistory, getAllIncome, getAllExpense, getMonthHistory,
 } from '../../utils';
-import { getAllHkbHist } from "../../apis";
-
-const data = async () => {
-  // api 호출 test
-  const dataaaa = await getAllHkbHist();
-  console.log(dataaaa);
-};
 
 const HkbPage = () => {
-  // 이 부분에서 호출을 하게 되면 api의 return 결과를 렌더링 해주어서 일단 따로 분리하였다.
-  // 추후에 개선 방법을 찾아보자..!
-  const res = data();
-  console.log(res);
-  const currentMonth = getState('currentMonth');
-  const hkbHistory = getState('hkbHistory');
-  const monthHistory = getMonthHistory(currentMonth, hkbHistory);
-  const monthIncome = getAllIncome(monthHistory);
-  const monthExpense = getAllExpense(monthHistory);
 
-  const daysHistory = getDaysHistory(monthHistory);
-  const days = Object.keys(daysHistory).sort().reverse();
+  function init() {
+    const currentMonth = getState('currentMonth');
+    const hkbHistory = getState('hkbHistory');
+    const monthHistory = getMonthHistory(currentMonth, hkbHistory);
+    const monthIncome = getAllIncome(monthHistory);
+    const monthExpense = getAllExpense(monthHistory);
+    const daysHistory = getDaysHistory(monthHistory);
+    const days = Object.keys(daysHistory).sort().reverse();
+
+    return { days, daysHistory, monthIncome, monthExpense };
+  }
+
+  const initData =  init();
+  const { monthIncome, monthExpense, daysHistory, days } = initData;
+
+  function onChange() {
+    const histList = document.querySelector('.history_list');
+    const initData =  init();
+    const { monthIncome, monthExpense, daysHistory, days } = initData;
+    histList.innerHTML = days.map((day) => DailyHistory(new Date(day), daysHistory[day])).join('');
+    setState('allIncome',monthIncome);
+    setState('allExpense',monthExpense)
+  }
+
+  registerEvent('hkbHistory',onChange);
 
   return (`
     <div class="hkb_page">

--- a/client/src/App/store/index.js
+++ b/client/src/App/store/index.js
@@ -3,10 +3,6 @@ const observer = {
     data: 'user1',
     eventHandler: () => {},
   },
-  account: {
-    data: ['거래 1', '거래 2'],
-    eventHandler: () => {},
-  },
   path: {
     data: window.location.pathname,
     eventHandler: () => {},
@@ -27,102 +23,24 @@ const observer = {
     data: 'category',
     eventHandler: () => {},
   },
+  allIncome: {
+    data: 0,
+    eventHandler: () => {},
+  },
+  allExpense: {
+    data: 0,
+    eventHandler: () => {},
+  },
+  payment: {
+    data:[],
+    eventHandler: () => {},
+  },
   category: {
-    data: [
-      {
-        name: '월급',
-        type: '수입',
-      },
-      {
-        name: '용돈',
-        type: '수입',
-      },
-      {
-        name: '기타수입',
-        type: '수입',
-      },
-      {
-        name: '식비',
-        type: '지출',
-      },
-      {
-        name: '생활',
-        type: '지출',
-      },
-      {
-        name: '쇼핑/뷰티',
-        type: '지출',
-      },
-      {
-        name: '교통',
-        type: '지출',
-      },
-      {
-        name: '의료/건강',
-        type: '지출',
-      },
-      {
-        name: '문화/여가',
-        type: '지출',
-      },
-      {
-        name: '미분류',
-        type: '지출',
-      },
-    ],
+    data: [],
     eventHandler: () => {},
   },
   hkbHistory: {
-    data: [
-      {
-        category: '쇼핑/뷰티',
-        content: '미용실',
-        payment: '현대카드',
-        amount: 26000,
-        type: '지출',
-        createdAt: new Date(),
-      },
-      {
-        category: '식비',
-        content: '맥도날드',
-        payment: '현대카드',
-        amount: 26000,
-        type: '지출',
-        createdAt: new Date(),
-      },
-      {
-        category: '월급',
-        content: '월급',
-        payment: '국민은행',
-        amount: 2000000,
-        type: '수입',
-        createdAt: new Date(),
-      },
-      {
-        category: '식비',
-        content: '홍콩반점',
-        payment: '현대카드',
-        amount: 6000,
-        type: '지출',
-        createdAt: new Date('2020-08-29'),
-      },
-      {
-        category: '식비',
-        content: '홍콩반점',
-        payment: '현대카드',
-        amount: 6000,
-        type: '지출',
-        createdAt: new Date('2020-08-28'),
-      },
-      {
-        category: '식비',
-        content: '홍콩반점',
-        payment: '현대카드',
-        amount: 6000,
-        type: '지출',
-        createdAt: new Date('2020-08-29'),
-      },
-    ],
+    data: [],
     eventHandler: () => {},
   },
 };

--- a/client/src/App/utils.js
+++ b/client/src/App/utils.js
@@ -11,6 +11,13 @@ export const numberWithCommas = (num) => {
   return commaNum;
 };
 
+export const numberWithoutCommas = (num) => {
+  // 반점 제거
+  const commaNum = num.toString().split(',').join('');
+
+  return parseInt(commaNum);
+};
+
 export const getMonth = (date) => {
   const month =
     date.getMonth() > 9 ? date.getMonth() + 1 : `0${date.getMonth() + 1}`;
@@ -28,6 +35,14 @@ export const getWeek = (date) => {
   return dayOfWeek;
 };
 
+export const getFullDate = (date, format) => {
+  const year = date.getFullYear();
+  const month = getMonth(date);
+  const day = getDate(date);
+  const dateForm = year+ format + month + format + day;
+  return dateForm;
+}
+
 // 해당 달에 맞는 히스토리 필터링
 export const getMonthHistory = (month, history) => history.filter(
   (item) => item.createdAt.getMonth() + 1 === month,
@@ -39,7 +54,7 @@ export const getDaysHistory = (history) => {
   // 변경한 배열 생성해주는 로직 push -> concat
   history.forEach((element) => {
     const date = element.createdAt;
-    const d = `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
+    const d = getFullDate(date, '.');
     daysHistory[d] = daysHistory[d] || [];
     daysHistory[d] = daysHistory[d].concat(element);
   });
@@ -102,4 +117,9 @@ export const createDashArray = (history) => {
   });
 
   return arr;
+};
+
+export const validation = (data) => {
+  console.log(data);
+  return data;
 };

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     port: 9000,
     proxy: {
       '/api/': {
-        // target: 'http://127.0.0.1:3000',
+        target: 'http://127.0.0.1:3000',
         changeOrigin: true,
       },
     },

--- a/server/controllers/category-controller.js
+++ b/server/controllers/category-controller.js
@@ -1,0 +1,15 @@
+const { CategoryDTO } = require('../models');
+const CategoryService = require('../services/category-service');
+
+async function findCategory(req, res) {
+  try {
+    const categoryList = await CategoryService.findCategory();
+    res.status(200).json({ success: true, payload: categoryList });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err });
+  }
+}
+
+module.exports = {
+  findCategory,
+};

--- a/server/controllers/hkbhist-controller.js
+++ b/server/controllers/hkbhist-controller.js
@@ -14,7 +14,10 @@ async function findHkbHistByUserId(req, res) {
 async function createHkbHist(req, res) {
   try {
     // req.body
-    res.status(200).json({ success: true, payload: null });
+    const userId = 'admin';
+    const data = { ...req.body, userId };
+    await HkbHistService.createHkbHist(data);
+    res.status(200).json({ success: true });
   } catch (err) {
     res.status(500).json({ success: false, message: err });
   }

--- a/server/controllers/payment-controller.js
+++ b/server/controllers/payment-controller.js
@@ -1,0 +1,16 @@
+const { PaymentDTO } = require('../models');
+const PaymentService = require('../services/payment-service');
+
+async function findPaymentByUserId(req, res) {
+  try {
+    const userId = 'admin';
+    const paymentList = await PaymentService.findPaymentByUserId(userId);
+    res.status(200).json({ success: true, payload: paymentList });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err });
+  }
+}
+
+module.exports = {
+  findPaymentByUserId,
+};

--- a/server/models/hkbhist-dto.js
+++ b/server/models/hkbhist-dto.js
@@ -9,6 +9,7 @@ class HkbHistDTO {
     user_id,
     createdAt,
     created_at,
+    type,
   }) {
     this.id = id;
     this.category = category;
@@ -17,6 +18,7 @@ class HkbHistDTO {
     this.amount = amount;
     this.createdAt = created_at || createdAt;
     this.userId = user_id || userId;
+    this.type = type;
   }
 }
 

--- a/server/repository/category-repo.js
+++ b/server/repository/category-repo.js
@@ -1,0 +1,19 @@
+const pool = require('../pool');
+const { CategoryDTO } = require('../models');
+
+async function findCategory() {
+  const conn = await pool.getConnection();
+  try{
+    const [rows] = await conn.query("SELECT * FROM Category");
+    const category = rows.map((row) => new CategoryDTO(row));
+    return category;
+  }catch(e){
+    console.log(e);
+  } finally {
+    conn.release();
+  }
+}
+
+module.exports = {
+  findCategory,
+}

--- a/server/repository/hkbhist-repo.js
+++ b/server/repository/hkbhist-repo.js
@@ -4,14 +4,35 @@ const { HkbHistDTO } = require('../models');
 async function findHkbHistByUserId(userId) {
   const conn = await pool.getConnection();
   try{
-    const [rows] = await conn.query(`SELECT * FROM HkbHist WHERE user_id = ?`, [userId]);
+    const [rows] = await conn.query("\
+    SELECT HkbHist.category, HkbHist.content, HkbHist.payment, HkbHist.amount, HkbHist.created_at, HkbHist.user_id, Category.type AS type\
+    FROM HkbHist\
+    JOIN Category ON HkbHist.category = Category.name\
+    WHERE user_id = ?"
+    , [userId]);
     const hkbHist = rows.map((row) => new HkbHistDTO(row));
     return hkbHist;
   }catch(e){
     console.log(e);
+  } finally {
+    conn.release();
   }
 }
 
+async function createHkbHist(data) {
+  const conn = await pool.getConnection();
+  try{
+    const { category, payment, amount, created_at, content, userId } = data;
+    await conn.query(
+      `INSERT INTO HkbHist (category,payment,amount,created_at,content,user_id) VALUES (?, ?, ?, ?, ?, ?)`,
+      [category, payment, amount, created_at, content, userId]);
+  }catch(e){
+    console.log(e);
+  } finally {
+    conn.release();
+  }
+}
 module.exports = {
   findHkbHistByUserId,
+  createHkbHist,
 };

--- a/server/repository/payment-repo.js
+++ b/server/repository/payment-repo.js
@@ -1,0 +1,19 @@
+const pool = require('../pool');
+const { PaymentDTO } = require('../models');
+
+async function findPaymentByUserId(userId) {
+  const conn = await pool.getConnection();
+  try{
+    const [rows] = await conn.query("SELECT * FROM Payment WHERE user_id= ?", [userId]);
+    const payment = rows.map((row) => new PaymentDTO(row));
+    return payment;
+  }catch(e){
+    console.log(e);
+  } finally {
+    conn.release();
+  }
+}
+
+module.exports = {
+  findPaymentByUserId,
+}

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -3,4 +3,6 @@ const categoryController = require('../controllers/category-controller');
 
 const router = express.Router();
 
-router.get('/', categoryController.findCategoryByType);
+router.get('/', categoryController.findCategory);
+
+module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,14 +1,14 @@
 const express = require('express');
 const hkbhist = require('./hkbhist');
-// const payment = require('./payment');
-// const category = require('./category');
+const payment = require('./payment');
+const category = require('./category');
 const user = require('./user');
 
 const router = express.Router();
 
 router.use('/hkbhist', hkbhist);
-// router.use('/payment', payment);
-// router.use('/category', category);
+router.use('/payment', payment);
+router.use('/category', category);
 router.use('/user', user);
 
 module.exports = router;

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -1,8 +1,10 @@
 const express = require('express');
-// const paymentController = require('../controllers/payment-controller');
+const paymentController = require('../controllers/payment-controller');
 
 const router = express.Router();
 
-// router.get('/', paymentController.findPaymentByUserId);
+router.get('/', paymentController.findPaymentByUserId);
 // router.post('/', paymentController.createPayment);
 // router.delete('/', paymentController.removePaymentByName);
+
+module.exports = router;

--- a/server/services/category-service.js
+++ b/server/services/category-service.js
@@ -1,0 +1,10 @@
+const CategoryRepo = require('../repository/category-repo');
+
+async function findCategory(userId) {
+  const categoryList = await CategoryRepo.findCategory(userId);
+  return categoryList;
+}
+
+module.exports = {
+  findCategory,
+};

--- a/server/services/hkbhist-service.js
+++ b/server/services/hkbhist-service.js
@@ -5,6 +5,13 @@ async function findHkbHistByUserId(userId) {
   return hkbHist;
 }
 
+async function createHkbHist(data) {
+  const hkbHist = await hkbHistRepo.createHkbHist(data);
+  return hkbHist;
+}
+
+
 module.exports = {
   findHkbHistByUserId,
+  createHkbHist,
 };

--- a/server/services/payment-service.js
+++ b/server/services/payment-service.js
@@ -1,0 +1,10 @@
+const PaymentRepo = require('../repository/payment-repo');
+
+async function findPaymentByUserId(userId) {
+  const paymentList = await PaymentRepo.findPaymentByUserId(userId);
+  return paymentList;
+}
+
+module.exports = {
+  findPaymentByUserId,
+};


### PR DESCRIPTION
- page/hkbhist/index.js 내역 추가 기능 구현
- 내역 추가 api 버튼 연결
- 초기 페이지 로드 시에 hkbhist, category, payment 데이터 조회 api 연동
- daliyHistory에서 CaseHistory 거꾸로 출력하게 수정
- 내역 추가되면 dailyHistory, hkbSum 컴포넌트 다시 렌더링 구현

백엔드 hkbhist, category, payment 구현
- controller, service, repository 추가
- route 연결