### PR TITLE
프론트엔드 hkbhist 페이지 내역 추가 오류 수정

### DIFF
--- a/client/src/App/event/hkbHist.js
+++ b/client/src/App/event/hkbHist.js
@@ -41,6 +41,7 @@ function resetForm() {
   amount.value = 0;
   content.value = '';
   contentsRemoveBtn.innerText = '내용 지우기';
+  setState('currentHistId', null);
 }
 
 export async function HkbHistClickEvent(e) {
@@ -58,7 +59,6 @@ export async function HkbHistClickEvent(e) {
       if (res.success) {
         getHkbHistory();
         setState('currentType', '수입');
-        setState('currentHistId', null);
         resetForm();
       }
     }


### PR DESCRIPTION
- 내역 추가 후 새 내역 등록 시 이전에 등록했던 내역이 업데이트 되었던 부분을 수정함.
=> currentHistId 를 reset 시켜주었다.